### PR TITLE
add(project): add support for Quartus 22.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -18,7 +18,7 @@ usage() {
 	echo
 	echo "Usage: build.sh [-v] [OPTION...]"
 	echo "  -v    Quartus version to build."
-	echo "        [13.0, 13.1, 17.0, 17.1, 18.1, 19.1, 20.1, 21.1]"
+	echo "        [13.0, 13.1, 17.0, 17.1, 18.1, 19.1, 20.1, 21.1, 22.1]"
 	echo
 	echo " Main modes of operation:"
 	echo "  -b    Build container using remote files."
@@ -29,7 +29,7 @@ usage() {
 	echo "  -c    Check local files integrity."
 	echo "  -o    Build Base OS."
 	echo
-	echo " eg. build.sh -v21.1 -b"
+	echo " eg. build.sh -v22.1 -b"
 	echo "     build.sh -vbase -o"
 	echo
 }
@@ -132,6 +132,8 @@ publish() {
     	tag_variation "${TAG_NAME}" "pocket"
     elif [ "${VERSION}" = "21.1" ]; then
     	tag_variation "${TAG_NAME}" "21.1.1"
+	elif [ "${VERSION}" = "22.1" ]; then
+    	tag_variation "${TAG_NAME}" "22.1.1"
     fi
 	echo "Done."
 }
@@ -163,6 +165,8 @@ publish_to_github() {
     	tag_variation "${GIT_TAG_NAME}" "pocket"
     elif [ "${VERSION}" = "21.1" ]; then
     	tag_variation "${GIT_TAG_NAME}" "21.1.1"
+	elif [ "${VERSION}" = "22.1" ]; then
+    	tag_variation "${GIT_TAG_NAME}" "22.1.1"
     fi
 	echo "Done."
 }
@@ -234,6 +238,14 @@ download() {
             fileArray[2]="21.1std.1/850/ib_installers/cyclone10lp-21.1.1.850.qdz"
             fileArray[3]="21.1std.1/850/ib_installers/cyclonev-21.1.1.850.qdz"
             fileArray[4]="21.1std.1/850/ib_installers/max10-21.1.1.850.qdz"
+			;;
+		"22.1")
+			echo "Downloading v22.1std.1.917"			              
+			fileArray[0]="22.1std.1/917/ib_installers/QuartusLiteSetup-22.1std.1.917-linux.run"
+			fileArray[1]="22.1std.1/917/ib_installers/cyclone-22.1std.1.917.qdz"
+			fileArray[2]="22.1std.1/917/ib_installers/cyclone10lp-22.1std.1.917.qdz"
+			fileArray[3]="22.1std.1/917/ib_installers/cyclonev-22.1std.1.917.qdz"
+			fileArray[4]="22.1std.1/917/ib_installers/max10-22.1std.1.917.qdz"
 			;;
 		*)   # Invalid option
 			echo "Error: Invalid Version"

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ These images are built from official installation files provided by Intel (speci
     - [`19.1`](https://github.com/raetro/sdk-docker-fpga/tree/master/quartus19.1) v19.1.0.670
     - [`20.1`](https://github.com/raetro/sdk-docker-fpga/tree/master/quartus20.1) v20.1.0.711
     - [`21.1`, `21.1.1`](https://github.com/raetro/sdk-docker-fpga/tree/master/quartus21.1) v21.1.1.850
+    - [`22.1`, `22.1.1`](https://github.com/raetro/sdk-docker-fpga/tree/master/quartus22.1) v22.1std.1.917
 
 ### Supported tag alias for specific FPGA projects
 

--- a/quartus22.1/local/Dockerfile
+++ b/quartus22.1/local/Dockerfile
@@ -1,0 +1,49 @@
+################################################################################
+# SPDX-License-Identifier: MIT
+# SPDX-FileType: SOURCE
+# SPDX-FileCopyrightText: (c) 2022, Marcus Andrade
+################################################################################
+
+# Install Quartus on a separated layer of the Docker image to shrink the image size.
+FROM raetro/quartus:base as install
+
+# Change the working directory
+WORKDIR /tmp
+
+# Add Quartus installation files
+ADD files/cyclone-22.1std.1.917.qdz                 .
+ADD files/cyclone10lp-22.1std.1.917.qdz             .
+ADD files/cyclonev-22.1std.1.917.qdz                .
+ADD files/max10-22.1std.1.917.qdz                   .
+ADD files/QuartusLiteSetup-22.1std.1.917-linux.run  .
+
+# Fix file permissions
+RUN chmod a+x QuartusLiteSetup-22.1std.1.917-linux.run                                                        && \
+    ./QuartusLiteSetup-22.1std.1.917-linux.run --mode unattended --accept_eula 1 --installdir /opt/intelFPGA  && \
+    rm -rf /opt/intelFPGA/uninstall/
+
+################################################################################
+
+# Create clean distribution image
+FROM raetro/quartus:base
+
+# Copy out Quartus instalation files to the image
+COPY --from=install /opt/intelFPGA/ /opt/intelFPGA/
+
+# Load the library from the host system.
+ENV LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4
+
+# Metadata Params
+ARG BUILD_DATE
+ARG BUILD_VERSION
+
+# Metadata
+LABEL \
+    org.opencontainers.image.vendor="Raetro.org"                                     \
+    org.opencontainers.image.title="raetro/quartus"                                  \
+    org.opencontainers.image.description="Intel Quartus Prime Synthesis Engine"      \
+    org.opencontainers.image.authors="sigs+fpga@raetro.org"                          \
+    org.opencontainers.image.url="https://github.com/raetro/sdk-docker-fpga"         \
+    org.opencontainers.image.source="https://github.com/raetro/sdk-docker-fpga.git"  \
+    org.opencontainers.image.created=$BUILD_DATE                                     \
+    org.opencontainers.image.version=$BUILD_VERSION

--- a/quartus22.1/local/files/file.lst
+++ b/quartus22.1/local/files/file.lst
@@ -1,0 +1,5 @@
+cbbfc3ffdcee8a2535b9e129bd7444f3fa18b71f  cyclone-22.1std.1.917.qdz
+a26747672b0e8f48c0e6691760760b3ce60cba42  cyclone10lp-22.1std.1.917.qdz
+379e51b9e908cd43b9515f93f42f2a230a405a60  cyclonev-22.1std.1.917.qdz
+c3a42e7dedae4ffad45320062b4492818df74f5e  max10-22.1std.1.917.qdz
+d1923058d69fe8c0593486d2a0b430133a48dd39  QuartusLiteSetup-22.1std.1.917-linux.run

--- a/quartus22.1/remote/Dockerfile
+++ b/quartus22.1/remote/Dockerfile
@@ -1,0 +1,52 @@
+################################################################################
+# SPDX-License-Identifier: MIT
+# SPDX-FileType: SOURCE
+# SPDX-FileCopyrightText: (c) 2022, Marcus Andrade
+################################################################################
+
+# Install Quartus on a separated layer of the Docker image to shrink the image size.
+FROM raetro/quartus:base as install
+
+# Change the working directory
+WORKDIR /tmp
+
+# Intel CDN URL
+ARG INTEL_CDN="https://downloads.intel.com/akdlm/software/acdsinst"
+
+# Add Quartus installation files
+ADD ${INTEL_CDN}/22.1std.1/917/ib_installers/cyclone-22.1std.1.917.qdz                .
+ADD ${INTEL_CDN}/22.1std.1/917/ib_installers/cyclone10lp-22.1std.1.917.qdz            .
+ADD ${INTEL_CDN}/22.1std.1/917/ib_installers/cyclonev-22.1std.1.917.qdz               .
+ADD ${INTEL_CDN}/22.1std.1/917/ib_installers/max10-22.1std.1.917.qdz                  .
+ADD ${INTEL_CDN}/22.1std.1/917/ib_installers/QuartusLiteSetup-22.1std.1.917-linux.run .
+
+# Fix file permissions
+RUN chmod a+x QuartusLiteSetup-22.1std.1.917-linux.run                                                        && \
+    ./QuartusLiteSetup-22.1std.1.917-linux.run --mode unattended --accept_eula 1 --installdir /opt/intelFPGA  && \
+    rm -rf /opt/intelFPGA/uninstall/
+
+################################################################################
+
+# Create clean distribution image
+FROM raetro/quartus:base
+
+# Copy out Quartus instalation files to the image
+COPY --from=install /opt/intelFPGA/ /opt/intelFPGA/
+
+# Load the library from the host system.
+ENV LD_PRELOAD=/usr/lib/libtcmalloc_minimal.so.4
+
+# Metadata Params
+ARG BUILD_DATE
+ARG BUILD_VERSION
+
+# Metadata
+LABEL \
+    org.opencontainers.image.vendor="Raetro.org"                                     \
+    org.opencontainers.image.title="raetro/quartus"                                  \
+    org.opencontainers.image.description="Intel Quartus Prime Synthesis Engine"      \
+    org.opencontainers.image.authors="sigs+fpga@raetro.org"                          \
+    org.opencontainers.image.url="https://github.com/raetro/sdk-docker-fpga"         \
+    org.opencontainers.image.source="https://github.com/raetro/sdk-docker-fpga.git"  \
+    org.opencontainers.image.created=$BUILD_DATE                                     \
+    org.opencontainers.image.version=$BUILD_VERSION


### PR DESCRIPTION
It looks like 22.1 requires a newer version of libstdc++ than the one provided in the host system so modified the `LD_PRELOAD` variable to let it use the version shipped with Quartus itself.

Not sure why this was set to use the host system one before so there may be implications that I don't understand here.